### PR TITLE
Fix search/navbar component props and siteconfig import for dev env

### DIFF
--- a/src/lib/components/NavigationBar.svelte
+++ b/src/lib/components/NavigationBar.svelte
@@ -2,12 +2,11 @@
 
   import { page } from '$app/stores';
   import Search from './Search.svelte';
-  import { siteConfig } from '/site.config.js';
 
   export let navbarItems = [];
   export let activePath = '';
-  export let showSearch = siteConfig?.search?.enabled ?? false;
-  export let searchPlaceholder = siteConfig?.search?.placeholder ?? "Search...";
+  export let showSearch = false;
+  export let searchPlaceholder = "Search...";
   
   let isMenuOpen = false;
   let isHidden = false;

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -1,4 +1,5 @@
 import { getContentDirectories, getContentByDirectory } from '$lib/cms/content-processor';
+import siteConfig from '../../site.config.js';
 
 /** @type {import('./$types').LayoutServerLoad} */
 export function load() {
@@ -9,21 +10,22 @@ export function load() {
   const enhancedDirectories = directories.map(directory => {
     // Get content from this directory
     const directoryContent = getContentByDirectory(directory.name);
-    
+
     // Extract pages as subpages
     const subpages = directoryContent.map((content) => ({
       title: content.metadata.title,
       url: content.url
     }));
-    
+
     // Return enhanced directory object
     return {
       ...directory,
       subpages
     };
   });
-  
+
   return {
-    globalDirectories: enhancedDirectories
+    globalDirectories: enhancedDirectories,
+    searchConfig: siteConfig.search
   };
 } 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
   export let data;
 
   $: globalDirectories = data.globalDirectories;
+  $: searchConfig = data.searchConfig;
   $: currentPath = $page.url.pathname;
 
   // Enable View Transitions API only for blog pages
@@ -31,7 +32,11 @@
   });
 </script>
 
-<NavigationBar navbarItems={globalDirectories} />
+<NavigationBar
+  navbarItems={globalDirectories}
+  showSearch={searchConfig?.enabled ?? false}
+  searchPlaceholder={searchConfig?.placeholder ?? "Search..."}
+/>
 
 <main>
   <slot />


### PR DESCRIPTION
## What this PR does / why we need it

Importing site.config.js within the navigation bar component for search configuration failed in vite dev server, modified the component to just have props set by the server side js files which can import the config.
