### PR TITLE
#114 Updated view code button

### DIFF
--- a/templates/developer-portfolio/src/lib/components/RepoCard.svelte
+++ b/templates/developer-portfolio/src/lib/components/RepoCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Star, GitFork, Code } from 'lucide-svelte';
+	import { Star, GitFork } from 'lucide-svelte';
 
 	export let repo: {
 		name: string;
@@ -31,10 +31,10 @@
 			</div>
 			<a
 				href="/github1s/{repoPath}"
-				class="p-1.5 rounded-md text-fg-muted hover:text-accent-fg hover:bg-canvas-subtle transition-colors"
+				class="view-code-link"
 				title="Open in VS Code"
 			>
-				<Code size={14} />
+				&lt;View Code&gt;
 			</a>
 		</div>
 		<p class="text-xs text-fg-muted mb-4 line-clamp-2">
@@ -63,3 +63,20 @@
 		{/if}
 	</div>
 </div>
+
+<style>
+	.view-code-link {
+		font-size: 0.75rem;
+		color: var(--fg-muted, #8b949e);
+		text-decoration: none;
+		padding: 0.25rem 0.5rem;
+		border-radius: 4px;
+		transition: all 0.2s ease;
+		white-space: nowrap;
+	}
+
+	.view-code-link:hover {
+		color: var(--accent-fg, #58a6ff);
+		background: var(--canvas-subtle, #161b22);
+	}
+</style>


### PR DESCRIPTION
**Purpose of this pull request:** 
This PR fixes following bugs/feat requests:
The "<>" link to open github1s embedded is non-obvious, and should be text instead of an svg. Let's change the text to view code.

**(optional) Issues fixed**: fixes #114 

## IMPORTANT - UI CHANGE DEMONSTRATION

If making a change that changes the existing UI, or adds/changes new UI elements like components, themes, or templates, you MUST include screenshots or demos/recordings of your changes:

Screenshots:
<img width="341" height="139" alt="Screenshot 2026-01-06 at 1 32 45 PM" src="https://github.com/user-attachments/assets/0e36cfc5-c98c-4ef5-8db3-4bb994842bc5" />

Site preview link:

## Other things worth discussing regarding PR:

Anything not covered by previous sections
