### PR TITLE
removed unused badge

### DIFF
--- a/templates/developer-portfolio/src/routes/timeline/+page.svelte
+++ b/templates/developer-portfolio/src/routes/timeline/+page.svelte
@@ -315,12 +315,7 @@
 <!-- HUD / UI Overlay -->
 <div class="hud">
     <div class="hud-top">
-        <div class="terminal-badge">
-            <span class="dot red"></span>
-            <span class="dot yellow"></span>
-            <span class="dot green"></span>
-            <span class="txt">bash — timeline</span>
-        </div>
+        
     </div>
     
     <div class="hud-center">


### PR DESCRIPTION
**Purpose of this pull request:**
There was an used badges on timeline page, it's removed. At the moment, the page looks like this:
<img width="1905" height="991" alt="Screenshot 2026-01-06 at 1 30 49 PM" src="https://github.com/user-attachments/assets/a3d53fb1-96d2-4161-b011-64213fe73c54" />

**(optional) Issues fixed**: fixes #<issue number>, fixes #<issue number>

## IMPORTANT - UI CHANGE DEMONSTRATION

If making a change that changes the existing UI, or adds/changes new UI elements like components, themes, or templates, you MUST include screenshots or demos/recordings of your changes:

Screenshots:

Site preview link:

## Other things worth discussing regarding PR:

Anything not covered by previous sections
