### PR TITLE
Enhance postinstall.js to conditionally copy content based on templat…

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -15,10 +15,19 @@ async function setupStatueSSG(options = {}) {
   console.log(chalk.blue(`🗿 Statue SSG - Initializing '${templateName}' template...`));
 
   // 1. Copy content
-  const contentDir = path.join(sourceDir, 'content');
-  if (fs.existsSync(contentDir)) {
-    fs.copySync(contentDir, path.join(targetDir, 'content'), { overwrite: false });
-    console.log(chalk.green('✓ content copied'));
+  // If template has its own content folder, skip default content 
+  // Otherwise, copy default content as fallback
+  const templateContentDir = path.join(sourceDir, 'templates', templateName, 'content');
+  const hasTemplateContent = fs.existsSync(templateContentDir);
+
+  if (!hasTemplateContent) {
+    const contentDir = path.join(sourceDir, 'content');
+    if (fs.existsSync(contentDir)) {
+      fs.copySync(contentDir, path.join(targetDir, 'content'), { overwrite: false });
+      console.log(chalk.green('✓ content copied'));
+    }
+  } else {
+    console.log(chalk.gray('⊘ using template content folder'));
   }
 
   // 2. Copy shared resources (favicon, robots.txt, etc.) - base layer
@@ -62,8 +71,7 @@ async function setupStatueSSG(options = {}) {
   console.log(chalk.green(`✓ ${templateName} template copied`));
 
   // Copy template's content if exists
-  const templateContentDir = path.join(templateDir, 'content');
-  if (fs.existsSync(templateContentDir)) {
+  if (hasTemplateContent) {
     fs.copySync(templateContentDir, path.join(targetDir, 'content'), { overwrite: true });
   }
 


### PR DESCRIPTION

**Purpose of this pull request:**
When using a custom template that has its own content folder,
  don't copy the default content (docs, legal, etc.) - only use the template's content.
  Templates without a content folder still get the default content as fallback.

**(optional) Issues fixed**: fixes #<issue number>, fixes #<issue number>

## IMPORTANT - UI CHANGE DEMONSTRATION

If making a change that changes the existing UI, or adds/changes new UI elements like components, themes, or templates, you MUST include screenshots or demos/recordings of your changes:

Screenshots:

Site preview link:

## Other things worth discussing regarding PR:

Anything not covered by previous sections
