### PR TITLE
fix: increase maximum attempts for preview server readiness in docker…

### DIFF
--- a/test/hermetic/docker_test.sh
+++ b/test/hermetic/docker_test.sh
@@ -26,7 +26,7 @@ echo "Container ID: $CONTAINER_ID"
 echo "Waiting for preview server to start..."
 
 # Step: Keep curling the container to see when npm run preview starts successfully
-MAX_ATTEMPTS=30
+MAX_ATTEMPTS=60
 ATTEMPT=0
 SUCCESS=false
 SERVER_URL="http://localhost:3000"


### PR DESCRIPTION
**Purpose of this pull request:**
Some tests were failing on certain PRs because the Statue build time increased. We’ve increased the max retry attempts from 30 to 60 to make the tests more reliable.
**(optional) Issues fixed**: fixes #<issue number>, fixes #<issue number>

## IMPORTANT - UI CHANGE DEMONSTRATION

If making a change that changes the existing UI, or adds/changes new UI elements like components, themes, or templates, you MUST include screenshots or demos/recordings of your changes:

Screenshots:

Site preview link:

## Other things worth discussing regarding PR:

Anything not covered by previous sections
