### PR TITLE
fix: migrate magicui components to svelte 5 runes mode

### DIFF
--- a/src/lib/components/magicui/components/AnimatedBeam/AnimatedBeam.svelte
+++ b/src/lib/components/magicui/components/AnimatedBeam/AnimatedBeam.svelte
@@ -11,22 +11,43 @@ All components in this directory are sourced from the svelte-animations project 
   import { onMount, tick } from "svelte";
   import { M, Motion } from "svelte-motion";
 
-  export let containerRef;
-  export let fromRef;
-  export let toRef;
-  export let curvature = 0;
-  export let reverse = false; // Include the reverse pro;
-  export let duration = Math.random() * 3 + 4;
-  export let delay = 0;
-  export let pathColor = "gray";
-  export let pathWidth = 2;
-  export let pathOpacity = 0.2;
-  export let gradientStartColor = "#ffaa40";
-  export let gradientStopColor = "#9c40ff";
-  export let startXOffset = 0;
-  export let startYOffset = 0;
-  export let endXOffset = 0;
-  export let endYOffset = 0;
+  interface Props {
+    containerRef: any;
+    fromRef: any;
+    toRef: any;
+    curvature?: number;
+    reverse?: boolean;
+    duration?: number;
+    delay?: number;
+    pathColor?: string;
+    pathWidth?: number;
+    pathOpacity?: number;
+    gradientStartColor?: string;
+    gradientStopColor?: string;
+    startXOffset?: number;
+    startYOffset?: number;
+    endXOffset?: number;
+    endYOffset?: number;
+  }
+
+  let {
+    containerRef,
+    fromRef,
+    toRef,
+    curvature = 0,
+    reverse = false,
+    duration = Math.random() * 3 + 4,
+    delay = 0,
+    pathColor = "gray",
+    pathWidth = 2,
+    pathOpacity = 0.2,
+    gradientStartColor = "#ffaa40",
+    gradientStopColor = "#9c40ff",
+    startXOffset = 0,
+    startYOffset = 0,
+    endXOffset = 0,
+    endYOffset = 0
+  }: Props = $props();
 
   let id = crypto.randomUUID().slice(0, 8);
   let pathD = "";

--- a/src/lib/components/magicui/components/CircularProgressBar/CircularProgressBar.svelte
+++ b/src/lib/components/magicui/components/CircularProgressBar/CircularProgressBar.svelte
@@ -8,11 +8,21 @@ All components in this directory are sourced from the svelte-animations project 
 -->
 
 <script lang="ts">
-    export let max: number = 100;
-    export let value: number = 0;
-    export let min: number = 0;
-    export let gaugePrimaryColor: string = "#f00";
-    export let gaugeSecondaryColor: string = "#ddd";
+    interface Props {
+      max?: number;
+      value?: number;
+      min?: number;
+      gaugePrimaryColor?: string;
+      gaugeSecondaryColor?: string;
+    }
+
+    let {
+      max = 100,
+      value = 0,
+      min = 0,
+      gaugePrimaryColor = "#f00",
+      gaugeSecondaryColor = "#ddd"
+    }: Props = $props();
 
     let circumference = 2 * Math.PI * 45;
     let percentPx = circumference / 100;

--- a/src/lib/components/magicui/components/Dock/Dock.svelte
+++ b/src/lib/components/magicui/components/Dock/Dock.svelte
@@ -12,9 +12,17 @@ All components in this directory are sourced from the svelte-animations project 
   import { Motion, useMotionValue } from "svelte-motion";
   let DEFAULT_MAGNIFICATION = 60;
   let DEFAULT_DISTANCE = 140;
-  export let direction: "top" | "middle" | "bottom" = "top";
-  export let distance: number = DEFAULT_DISTANCE;
-  export let magnification: number = DEFAULT_MAGNIFICATION;
+  interface Props {
+    direction?: "top" | "middle" | "bottom";
+    distance?: number;
+    magnification?: number;
+  }
+
+  let {
+    direction = "top",
+    distance = DEFAULT_DISTANCE,
+    magnification = DEFAULT_MAGNIFICATION
+  }: Props = $props();
 
   let dockVariants = "mx-auto w-max mt-8 h-[80px] p-3 flex gap-2 rounded-2xl border supports-backdrop-blur:bg-white/10 supports-backdrop-blur:dark:bg-black/10 backdrop-blur-md";
   let mouseX = useMotionValue(Infinity);

--- a/src/lib/components/magicui/components/Dock/DockIcon.svelte
+++ b/src/lib/components/magicui/components/Dock/DockIcon.svelte
@@ -17,8 +17,12 @@ All components in this directory are sourced from the svelte-animations project 
   $effect(() => {
     console.log(mouseX.current, "---");
   });
-  export let distance: number = DEFAULT_DISTANCE;
-  export let magnification: number = DEFAULT_MAGNIFICATION;
+  interface Props {
+    distance?: number;
+    magnification?: number;
+  }
+
+  let { distance = DEFAULT_DISTANCE, magnification = DEFAULT_MAGNIFICATION }: Props = $props();
   let ref: HTMLElement;
   let distanceCalc = useTransform(mouseX, (val: number) => {
     const bounds = ref?.getBoundingClientRect() ?? { x: 0, width: 0 };

--- a/src/lib/components/magicui/components/Globe/Globe.svelte
+++ b/src/lib/components/magicui/components/Globe/Globe.svelte
@@ -18,10 +18,17 @@ All components in this directory are sourced from the svelte-animations project 
 		precision: 0.005
 	});
 
-	// Optional color overrides - if not provided, will use CSS theme variables
-	export let baseColorOverride: string | undefined = undefined;
-	export let markerColorOverride: string | undefined = undefined;
-	export let glowColorOverride: string | undefined = undefined;
+	interface Props {
+		baseColorOverride?: string | undefined;
+		markerColorOverride?: string | undefined;
+		glowColorOverride?: string | undefined;
+	}
+
+	let {
+		baseColorOverride = undefined,
+		markerColorOverride = undefined,
+		glowColorOverride = undefined
+	}: Props = $props();
 
 	let pointerInteracting: any = null;
 	let pointerInteractionMovement = 0;

--- a/src/lib/components/magicui/components/HeroVideoDialog/HeroVideoDialog.svelte
+++ b/src/lib/components/magicui/components/HeroVideoDialog/HeroVideoDialog.svelte
@@ -29,11 +29,21 @@ All components in this directory are sourced from the svelte-animations project 
   // 	thumbnailAlt?: string;
   // }
 
-  export let animationStyle: AnimationStyle = "from-center";
-  export let videoSrc: string;
-  export let thumbnailSrc: string; 
-  export let thumbnailAlt: string = "Video thumbnail";
-  export let iconColor: string = "white";
+  interface Props {
+    animationStyle?: AnimationStyle;
+    videoSrc: string;
+    thumbnailSrc: string;
+    thumbnailAlt?: string;
+    iconColor?: string;
+  }
+
+  let {
+    animationStyle = "from-center",
+    videoSrc,
+    thumbnailSrc,
+    thumbnailAlt = "Video thumbnail",
+    iconColor = "white"
+  }: Props = $props();
 
   const isVideoOpen = writable(false);
   const isCloseHovered = writable(false);

--- a/src/lib/components/magicui/components/features/FeatureCard.svelte
+++ b/src/lib/components/magicui/components/features/FeatureCard.svelte
@@ -13,10 +13,7 @@ All components in this directory are sourced from the svelte-animations project 
 
   // Svelte 5 Code : https://svelte.dev/playground/39866a136f0d4268821e5ae901dce47f?version=5.0.5
 
-  export let collapseDelay = 5000;
-  export let ltr = false;
-  export let linePosition: "left" | "right" | "top" | "bottom" = "left";
-  export let data: Array<{
+  interface FeatureData {
     id: number;
     title: string;
     content: string;
@@ -24,7 +21,21 @@ All components in this directory are sourced from the svelte-animations project 
     video?: string;
     poster?: string;
     icon?: any;
-  }> = [];
+  }
+
+  interface Props {
+    collapseDelay?: number;
+    ltr?: boolean;
+    linePosition?: "left" | "right" | "top" | "bottom";
+    data?: Array<FeatureData>;
+  }
+
+  let {
+    collapseDelay = 5000,
+    ltr = false,
+    linePosition = "left",
+    data = []
+  }: Props = $props();
 
   let currentIndex = writable(-1);
   let carouselRef: HTMLUListElement;

--- a/src/lib/components/magicui/text-animations/BlurIn/BlurInText.svelte
+++ b/src/lib/components/magicui/text-animations/BlurIn/BlurInText.svelte
@@ -10,15 +10,25 @@ All components in this directory are sourced from the svelte-animations project 
 <script lang="ts">
   import { Motion } from "svelte-motion";
 
-  export let word: string = "Blur In";
-  export let variant: {
+  interface Variant {
     hidden: { filter: string; opacity: number };
     visible: { filter: string; opacity: number };
-  } = {
-    hidden: { filter: "blur(10px)", opacity: 0 },
-    visible: { filter: "blur(0px)", opacity: 1 },
-  };
-  export let duration: number = 1;
+  }
+
+  interface Props {
+    word?: string;
+    variant?: Variant;
+    duration?: number;
+  }
+
+  let {
+    word = "Blur In",
+    variant = {
+      hidden: { filter: "blur(10px)", opacity: 0 },
+      visible: { filter: "blur(0px)", opacity: 1 },
+    },
+    duration = 1
+  }: Props = $props();
 
   let defaultVariants = {
     hidden: { filter: "blur(10px)", opacity: 0 },

--- a/src/lib/components/magicui/text-animations/BoxReveal/BoxReveal.svelte
+++ b/src/lib/components/magicui/text-animations/BoxReveal/BoxReveal.svelte
@@ -12,9 +12,17 @@ All components in this directory are sourced from the svelte-animations project 
   import { Motion, useAnimation } from "svelte-motion";
   import { onMount } from "svelte";
 
-  export let width = "fit-content";
-  export let boxColor: string | undefined = undefined;
-  export let duration = 0.5;
+  interface Props {
+    width?: string;
+    boxColor?: string | undefined;
+    duration?: number;
+  }
+
+  let {
+    width = "fit-content",
+    boxColor = undefined,
+    duration = 0.5
+  }: Props = $props();
 
   let themeColor = "";
 

--- a/src/lib/components/magicui/text-animations/FlipText/FlipText.svelte
+++ b/src/lib/components/magicui/text-animations/FlipText/FlipText.svelte
@@ -10,13 +10,27 @@ All components in this directory are sourced from the svelte-animations project 
 <script lang="ts">
   import { AnimatePresence, Motion } from "svelte-motion";
 
-  export let word = "Flip Text";
-  export let duration = 0.5;
-  export let delayMultiple = 0.08;
-  export let framerProps = {
-    hidden: { rotateX: -90, opacity: 0 },
-    visible: { rotateX: 0, opacity: 1 },
-  };
+  interface FramerProps {
+    hidden: { rotateX: number; opacity: number };
+    visible: { rotateX: number; opacity: number };
+  }
+
+  interface Props {
+    word?: string;
+    duration?: number;
+    delayMultiple?: number;
+    framerProps?: FramerProps;
+  }
+
+  let {
+    word = "Flip Text",
+    duration = 0.5,
+    delayMultiple = 0.08,
+    framerProps = {
+      hidden: { rotateX: -90, opacity: 0 },
+      visible: { rotateX: 0, opacity: 1 },
+    }
+  }: Props = $props();
   let wordsspilit = word.split("");
 </script>
 

--- a/src/lib/components/magicui/text-animations/GradualSpacing/GradualSpacing.svelte
+++ b/src/lib/components/magicui/text-animations/GradualSpacing/GradualSpacing.svelte
@@ -10,13 +10,27 @@ All components in this directory are sourced from the svelte-animations project 
 <script lang="ts">
   import { AnimatePresence, Motion } from "svelte-motion";
 
-  export let words = "Gradual Spacing";
-  export let duration = 0.5;
-  export let delayMultiple = 0.04;
-  export let framerProps = {
-    hidden: { opacity: 0, x: -20 },
-    visible: { opacity: 1, x: 0 },
-  };
+  interface FramerProps {
+    hidden: { opacity: number; x: number };
+    visible: { opacity: number; x: number };
+  }
+
+  interface Props {
+    words?: string;
+    duration?: number;
+    delayMultiple?: number;
+    framerProps?: FramerProps;
+  }
+
+  let {
+    words = "Gradual Spacing",
+    duration = 0.5,
+    delayMultiple = 0.04,
+    framerProps = {
+      hidden: { opacity: 0, x: -20 },
+      visible: { opacity: 1, x: 0 },
+    }
+  }: Props = $props();
   let wordsspilit = words.split("");
 </script>
 

--- a/src/lib/components/magicui/text-animations/LetterPullUp/LetterPullUp.svelte
+++ b/src/lib/components/magicui/text-animations/LetterPullUp/LetterPullUp.svelte
@@ -10,8 +10,12 @@ All components in this directory are sourced from the svelte-animations project 
 <script lang="ts">
   import { AnimatePresence, Motion } from "svelte-motion";
 
-  export let words = "Letter Pull Up";
-  export let delay = 0.05;
+  interface Props {
+    words?: string;
+    delay?: number;
+  }
+
+  let { words = "Letter Pull Up", delay = 0.05 }: Props = $props();
   let pullupVariant = {
     hidden: { y: 100, opacity: 0 },
     visible: (i: any) => ({

--- a/src/lib/components/magicui/text-animations/NumberTicker/NumberTicker.svelte
+++ b/src/lib/components/magicui/text-animations/NumberTicker/NumberTicker.svelte
@@ -10,14 +10,22 @@ All components in this directory are sourced from the svelte-animations project 
 <script lang="ts">
   import { cubicOut } from "svelte/easing";
   import { onMount } from "svelte";
-  import { spring, tweened } from "svelte/motion";
-  export let value = 100;
-  export let initial = 0;
-  export let duration = 6000;
+  import { tweened } from "svelte/motion";
+
+  interface Props {
+    value?: number;
+    initial?: number;
+    duration?: number;
+    [key: string]: any;
+  }
+
+  let { value = 100, initial = 0, duration = 6000, ...restProps }: Props = $props();
+
   let num = tweened(initial, {
     duration: duration,
     easing: cubicOut,
   });
+
   onMount(() => {
     num.set(value);
   });
@@ -25,7 +33,7 @@ All components in this directory are sourced from the svelte-animations project 
 
 <div
   class="inline-block  text-black dark:text-white tracking-normal"
-  {...$$restProps}
+  {...restProps}
 >
   {$num.toFixed(0)}
 </div>

--- a/src/lib/components/magicui/text-animations/TypingAnimation/TypingAnimation.svelte
+++ b/src/lib/components/magicui/text-animations/TypingAnimation/TypingAnimation.svelte
@@ -10,8 +10,12 @@ All components in this directory are sourced from the svelte-animations project 
 <script lang="ts">
   import { onMount } from "svelte";
 
-  export let text: string = "Typing Animation";
-  export let duration: number = 200;
+  interface Props {
+    text?: string;
+    duration?: number;
+  }
+
+  let { text = "Typing Animation", duration = 200 }: Props = $props();
 
   let displayedText = "";
   onMount(() => {

--- a/src/lib/components/magicui/text-animations/WordPullUp/WordPullUp.svelte
+++ b/src/lib/components/magicui/text-animations/WordPullUp/WordPullUp.svelte
@@ -10,20 +10,41 @@ All components in this directory are sourced from the svelte-animations project 
 <script lang="ts">
   import { Motion } from "svelte-motion";
 
-  export let words='Pull Up';
-  export let wrapperFramerProps = {
-    hidden: { opacity: 0 },
+  interface FramerProps {
+    hidden: { y: number; opacity: number };
+    show: { y: number; opacity: number };
+  }
+
+  interface WrapperFramerProps {
+    hidden: { opacity: number };
     show: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.25,
+      opacity: number;
+      transition: { staggerChildren: number };
+    };
+  }
+
+  interface Props {
+    words?: string;
+    wrapperFramerProps?: WrapperFramerProps;
+    framerProps?: FramerProps;
+  }
+
+  let {
+    words = 'Pull Up',
+    wrapperFramerProps = {
+      hidden: { opacity: 0 },
+      show: {
+        opacity: 1,
+        transition: {
+          staggerChildren: 0.25,
+        },
       },
     },
-  };
-  export let framerProps = {
-    hidden: { y: 20, opacity: 0 },
-    show: { y: 0, opacity: 1 },
-  };
+    framerProps = {
+      hidden: { y: 20, opacity: 0 },
+      show: { y: 0, opacity: 1 },
+    }
+  }: Props = $props();
 
   let wordSplit = words.split(" ");
 </script>

--- a/src/lib/components/magicui/text-animations/WordRotate/WordRotate.svelte
+++ b/src/lib/components/magicui/text-animations/WordRotate/WordRotate.svelte
@@ -11,8 +11,12 @@ All components in this directory are sourced from the svelte-animations project 
   import { onMount } from "svelte";
   import { fly } from "svelte/transition";
 
-  export let words: string[] = ["Hello", "Svelte", "Coders"];
-  export let duration: number = 2100;
+  interface Props {
+    words?: string[];
+    duration?: number;
+  }
+
+  let { words = ["Hello", "Svelte", "Coders"], duration = 2100 }: Props = $props();
 
   let index = 0;
   let chnageIndex = () => {

--- a/src/lib/components/magicui/text-animations/WordsFadeIn/WordsFadeIn.svelte
+++ b/src/lib/components/magicui/text-animations/WordsFadeIn/WordsFadeIn.svelte
@@ -10,16 +10,29 @@ All components in this directory are sourced from the svelte-animations project 
 <script lang="ts">
   import { AnimatePresence, Motion } from "svelte-motion";
 
-  export let words = "Fade In";
-  export let delay = 0.19;
-  export let variants = {
-    hidden: { opacity: 0 },
-    visible: (i: any) => ({
-      y: 0,
-      opacity: 1,
-      transition: { delay: i * delay },
-    }),
-  };
+  interface Variants {
+    hidden: { opacity: number };
+    visible: (i: any) => { y: number; opacity: number; transition: { delay: number } };
+  }
+
+  interface Props {
+    words?: string;
+    delay?: number;
+    variants?: Variants;
+  }
+
+  let {
+    words = "Fade In",
+    delay = 0.19,
+    variants = {
+      hidden: { opacity: 0 },
+      visible: (i: any) => ({
+        y: 0,
+        opacity: 1,
+        transition: { delay: i * delay },
+      }),
+    }
+  }: Props = $props();
   let wordsspilit = words.split(" ");
 </script>
 


### PR DESCRIPTION
**Purpose of this pull request:**
Updated all MagicUI components to use Svelte 5 runes mode (`$props()` instead of `export let`).                               
                                                                                                                                
  ## Changes                                                                                                                    
  - Migrated 17 components from legacy `export let` to `$props()`                                                               
  - Added TypeScript `Props` interfaces                                                                                         
  - Fixed `$restProps` issue in NumberTicker     

**(optional) Issues fixed**: fixes #<issue number>, fixes #<issue number>

## IMPORTANT - UI CHANGE DEMONSTRATION

If making a change that changes the existing UI, or adds/changes new UI elements like components, themes, or templates, you MUST include screenshots or demos/recordings of your changes:

Screenshots:

Site preview link:

## Other things worth discussing regarding PR:

Anything not covered by previous sections
